### PR TITLE
Add Mac OS X build support

### DIFF
--- a/HaPlugin/HaPlugin.csproj
+++ b/HaPlugin/HaPlugin.csproj
@@ -35,22 +35,20 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath Condition="$(OS) == 'Windows_NT'">$(LocalAppData)\Loupedeck\Plugins\Ha\win\</OutputPath>
+    <OutputPath Condition="$(OS) == 'Windows_NT'">..\..\..\..\AppData\Local\Loupedeck\Plugins\HA\win\</OutputPath>
     <OutputPath Condition="$(OS) != 'Windows_NT'">$(HOME)/.local/share/Loupedeck/Plugins/Ha/mac/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\..\..\AppData\Local\Loupedeck\Plugins\HA\win\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath Condition="$(OS) == 'Windows_NT'">$(BaseOutputPath)$(Configuration)\win\</OutputPath>
+    <OutputPath Condition="$(OS) == 'Windows_NT'">bin\win\</OutputPath>
     <OutputPath Condition="$(OS) != 'Windows_NT'">$(BaseOutputPath)$(Configuration)/mac/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <OutputPath>bin\win\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>
@@ -58,7 +56,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Loupedeck\Loupedeck2\Newtonsoft.Json.dll</HintPath>
+      <HintPath Condition="$(OS) == 'Windows_NT'">..\..\..\..\..\..\Program Files (x86)\Loupedeck\Loupedeck2\Newtonsoft.Json.dll</HintPath>
+      <HintPath Condition="$(OS) != 'Windows_NT'">/Applications/Loupedeck.app/Contents/MonoBundle/Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PluginApi, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -77,7 +76,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="websocket-sharp, Version=5.8.0.17786, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Loupedeck\Loupedeck2\websocket-sharp.dll</HintPath>
+      <HintPath Condition="$(OS) == 'Windows_NT'">..\..\..\..\..\..\Program Files (x86)\Loupedeck\Loupedeck2\websocket-sharp.dll</HintPath>
+      <HintPath Condition="$(OS) != 'Windows_NT'">/Applications/Loupedeck.app/Contents/MonoBundle/websocket-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/HaPlugin/metadata/LoupedeckPackage.yaml
+++ b/HaPlugin/metadata/LoupedeckPackage.yaml
@@ -34,7 +34,7 @@ pluginFolderWin: win
 
 # Location of plugin files on macOS (relative to the plugin base directory).
 # This parameter is required to support Mac.
-#pluginFolderMac: mac
+pluginFolderMac: mac
 
 # List of supported devices.
 supportedDevices:

--- a/README.md
+++ b/README.md
@@ -34,18 +34,23 @@ Water Heater
 The plugin communicates via the [Websocket API](https://developers.home-assistant.io/docs/api/websocket/) of Home-Assistant.
 State changes are immediately reflect on your Loupedeck display.
 
-## Installation
+## Installation (Windows)
 - download the latest .lplug4 asset [here](https://github.com/schmic/Loupedeck-HomeAssistant/releases/latest)
 - install into the Loupedeck software
   - right click and select `Install Plugin`
 
 This plugin is not yet published to the official Loupedeck Store.
-Only available for Windows, tested with Loupedeck Live.
+Only pre-built for Windows, tested with Loupedeck Live.
+
+## Installation (Mac)
+- download the repo and build (debug) in VS for Mac
+- restart Loupedeck software, the plugin will automatically be picked up
 
 ## Configuration
 
 - Create the following path & file in your home folder:
-  `C:/Users/<USERNAME>/.loupedeck/homeassistant/homeassistant.json`
+  - Windows: `C:/Users/<USERNAME>/.loupedeck/homeassistant/homeassistant.json`
+  - Mac: `/Users/<USERNAME>/.loupedeck/homeassistant/homeassistant.json`
 - Copy & Paste the example into the file
 - Replace token and URL
   - for the URL you can simply use the URL from your browser, the plugin will do the rest


### PR DESCRIPTION
This commit adds conditional hints to support building the plugin on Mac OS X.

I have built and tested on Mac OS X 14.1.1 with VS for Mac 17.6.14 (build 413) and Loupedeck 5.9.1 and it works. I don't know enough about .NET/VS to package this as a `.lplug4` file sorry, however, running the Debug build will automatically install it into Loupedeck after a restart.